### PR TITLE
add donor, recipient, and match models

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -1,0 +1,5 @@
+class Donor < ActiveRecord::Base
+  belongs_to :organization_campaign
+  has_many :matches
+  has_many :recipients, through: :matches
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,0 +1,4 @@
+class Match < ActiveRecord::Base
+  belongs_to :donor
+  belongs_to :recipient
+end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,0 +1,5 @@
+class Recipient < ActiveRecord::Base
+  belongs_to :organization_campaign
+  has_many :matches
+  has_many :donors, through: :matches
+end

--- a/db/migrate/20160617190559_create_donors.rb
+++ b/db/migrate/20160617190559_create_donors.rb
@@ -1,0 +1,12 @@
+class CreateDonors < ActiveRecord::Migration
+  def change
+    create_table :donors do |t|
+      t.references :organization_campaign, index: true, foreign_key: true
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160617190605_create_recipients.rb
+++ b/db/migrate/20160617190605_create_recipients.rb
@@ -1,0 +1,16 @@
+class CreateRecipients < ActiveRecord::Migration
+  def change
+    create_table :recipients do |t|
+      t.references :organization_campaign, index: true, foreign_key: true
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+      t.string :street
+      t.string :city
+      t.string :state
+      t.string :zip_code
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160617191148_create_matches.rb
+++ b/db/migrate/20160617191148_create_matches.rb
@@ -1,0 +1,10 @@
+class CreateMatches < ActiveRecord::Migration
+  def change
+    create_table :matches do |t|
+      t.references :donor, index: true, foreign_key: true
+      t.references :recipient, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160617180808) do
+ActiveRecord::Schema.define(version: 20160617191148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,27 @@ ActiveRecord::Schema.define(version: 20160617180808) do
   end
 
   add_index "campaigns", ["volunteer_center_id"], name: "index_campaigns_on_volunteer_center_id", using: :btree
+
+  create_table "donors", force: :cascade do |t|
+    t.integer  "organization_campaign_id"
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "donors", ["organization_campaign_id"], name: "index_donors_on_organization_campaign_id", using: :btree
+
+  create_table "matches", force: :cascade do |t|
+    t.integer  "donor_id"
+    t.integer  "recipient_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "matches", ["donor_id"], name: "index_matches_on_donor_id", using: :btree
+  add_index "matches", ["recipient_id"], name: "index_matches_on_recipient_id", using: :btree
 
   create_table "organization_campaigns", force: :cascade do |t|
     t.integer  "organization_id"
@@ -43,6 +64,21 @@ ActiveRecord::Schema.define(version: 20160617180808) do
   end
 
   add_index "organizations", ["volunteer_center_id"], name: "index_organizations_on_volunteer_center_id", using: :btree
+
+  create_table "recipients", force: :cascade do |t|
+    t.integer  "organization_campaign_id"
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email"
+    t.string   "street"
+    t.string   "city"
+    t.string   "state"
+    t.string   "zip_code"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
+
+  add_index "recipients", ["organization_campaign_id"], name: "index_recipients_on_organization_campaign_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -70,7 +106,11 @@ ActiveRecord::Schema.define(version: 20160617180808) do
   end
 
   add_foreign_key "campaigns", "volunteer_centers"
+  add_foreign_key "donors", "organization_campaigns"
+  add_foreign_key "matches", "donors"
+  add_foreign_key "matches", "recipients"
   add_foreign_key "organization_campaigns", "campaigns"
   add_foreign_key "organization_campaigns", "organizations"
   add_foreign_key "organizations", "volunteer_centers"
+  add_foreign_key "recipients", "organization_campaigns"
 end

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Donor, type: :model do
+end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Match, type: :model do
+end

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Recipient, type: :model do
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Adds models for `donors`, `recipients`, and `matches` as a join table between the two. We may want to add more information to these tables but this is a starting point as we build out the admin features.

closes #19 
