### PR TITLE
Configure app to deploy to heroku

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+export ADMIN_EMAIL=admin@example.com
+export ADMIN_PASSWORD=password
+export DEVISE_MAILER=please-change-me-at-config-initializers-devise@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+
+# dotenv
+.env.*
+!.env.test

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+# TODO: update to 2.3.1
+ruby "2.3.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'
 # Use postgresql as the database for Active Record
@@ -30,6 +32,7 @@ gem 'rails-erd'
 gem 'devise'
 gem 'puma'
 gem 'cancancan'
+gem 'dotenv-rails'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -52,4 +55,8 @@ group :development do
   gem 'pry-rails'
   gem 'better_errors'
   gem 'binding_of_caller'
+end
+
+group :production do
+  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
     formtastic (3.1.4)
@@ -179,6 +183,11 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)
@@ -260,6 +269,7 @@ DEPENDENCIES
   cancancan
   coffee-rails (~> 4.1.0)
   devise
+  dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails
   pg (~> 0.18.4)
@@ -267,11 +277,15 @@ DEPENDENCIES
   puma
   rails (= 4.2.6)
   rails-erd
+  rails_12factor
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+RUBY VERSION
+   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.5

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['DEVISE_MAILER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,5 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 # TODO: change Default Admin info
-AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+AdminUser.create!(email: ENV['ADMIN_EMAIL'], password: ENV['ADMIN_PASSWORD'], password_confirmation: ENV['ADMIN_PASSWORD'])
 VolunteerCenter.create(name: 'Durham, NC Volunteer Center')


### PR DESCRIPTION
Makes necessary changes to be able to deploy to heroku. Moves sensitive hard coded strings to environment variables and adds dotenv to manage them. The default load order will be
`.env` -> `.env.(environment name)` -> `.env.local` -> environment variables.
This means variables added with

```
heroku config:set NAME=value
```

as described [here](https://devcenter.heroku.com/articles/config-vars) will override values in .env allowing us to more securely manage email addresses and passwords.

You can check out the app [here](https://cryptic-escarpment-25093.herokuapp.com/). We should change that url from `cryptic-escarpment-25093` to something more descriptive later.

I'm having some troubles caused by how I set up rbenv, and cannot install 2.3.1. I think in production it would be best to use 2.3.1 for security purposes, but I can't configure the ruby version in the Gemfile and install dependencies with 2.3.1 on my own machine.
