### PR TITLE
add membership and remove donors

### DIFF
--- a/app/models/donor.rb
+++ b/app/models/donor.rb
@@ -1,5 +1,0 @@
-class Donor < ActiveRecord::Base
-  belongs_to :organization_campaign
-  has_many :matches
-  has_many :recipients, through: :matches
-end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,4 +1,4 @@
 class Match < ActiveRecord::Base
-  belongs_to :donor
+  belongs_to :membership
   belongs_to :recipient
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,4 @@
+class Membership < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :organization
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,8 @@
 class Organization < ActiveRecord::Base
   belongs_to :volunteer_center
   has_many :organization_campaigns
+  has_many :memberships
+  has_many :users, through: :memberships
 
   has_attached_file :logo, styles: { medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
   validates_attachment_content_type :logo, content_type: /\Aimage\/.*\Z/

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,5 +1,5 @@
 class Recipient < ActiveRecord::Base
   belongs_to :organization_campaign
   has_many :matches
-  has_many :donors, through: :matches
+  has_many :memberships, through: :matches
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+
+  has_many :memberships
+  has_many :organizations, through: :memberships
 end

--- a/db/migrate/20160618154314_create_memberships.rb
+++ b/db/migrate/20160618154314_create_memberships.rb
@@ -3,6 +3,7 @@ class CreateMemberships < ActiveRecord::Migration
     create_table :memberships do |t|
       t.references :organization, index: true, foreign_key: true
       t.references :user, index: true, foreign_key: true
+      t.boolean :send_email
 
       t.timestamps null: false
     end

--- a/db/migrate/20160618154314_create_memberships.rb
+++ b/db/migrate/20160618154314_create_memberships.rb
@@ -1,0 +1,10 @@
+class CreateMemberships < ActiveRecord::Migration
+  def change
+    create_table :memberships do |t|
+      t.references :organization, index: true, foreign_key: true
+      t.references :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160618155316_add_name_fields_to_user.rb
+++ b/db/migrate/20160618155316_add_name_fields_to_user.rb
@@ -1,0 +1,6 @@
+class AddNameFieldsToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/migrate/20160618155925_remove_donors.rb
+++ b/db/migrate/20160618155925_remove_donors.rb
@@ -1,0 +1,8 @@
+class RemoveDonors < ActiveRecord::Migration
+  def change
+    remove_reference :matches, :donor
+    add_reference :matches, :membership, index: true, foreign_key: true
+
+    drop_table :donors
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 20160618155925) do
   create_table "memberships", force: :cascade do |t|
     t.integer  "organization_id"
     t.integer  "user_id"
+    t.boolean  "send_email"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160618005102) do
+ActiveRecord::Schema.define(version: 20160618155925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,27 +65,26 @@ ActiveRecord::Schema.define(version: 20160618005102) do
 
   add_index "campaigns", ["volunteer_center_id"], name: "index_campaigns_on_volunteer_center_id", using: :btree
 
-  create_table "donors", force: :cascade do |t|
-    t.integer  "organization_campaign_id"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "email"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-  end
-
-  add_index "donors", ["organization_campaign_id"], name: "index_donors_on_organization_campaign_id", using: :btree
-
   create_table "matches", force: :cascade do |t|
-    t.integer  "donor_id"
     t.integer  "recipient_id"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.boolean  "fulfilled",    default: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.boolean  "fulfilled",     default: false
+    t.integer  "membership_id"
   end
 
-  add_index "matches", ["donor_id"], name: "index_matches_on_donor_id", using: :btree
+  add_index "matches", ["membership_id"], name: "index_matches_on_membership_id", using: :btree
   add_index "matches", ["recipient_id"], name: "index_matches_on_recipient_id", using: :btree
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer  "organization_id"
+    t.integer  "user_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "memberships", ["organization_id"], name: "index_memberships_on_organization_id", using: :btree
+  add_index "memberships", ["user_id"], name: "index_memberships_on_user_id", using: :btree
 
   create_table "organization_campaigns", force: :cascade do |t|
     t.integer  "organization_id"
@@ -145,6 +144,8 @@ ActiveRecord::Schema.define(version: 20160618005102) do
     t.inet     "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "first_name"
+    t.string   "last_name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -158,9 +159,10 @@ ActiveRecord::Schema.define(version: 20160618005102) do
   end
 
   add_foreign_key "campaigns", "volunteer_centers"
-  add_foreign_key "donors", "organization_campaigns"
-  add_foreign_key "matches", "donors"
+  add_foreign_key "matches", "memberships"
   add_foreign_key "matches", "recipients"
+  add_foreign_key "memberships", "organizations"
+  add_foreign_key "memberships", "users"
   add_foreign_key "organization_campaigns", "campaigns"
   add_foreign_key "organization_campaigns", "organizations"
   add_foreign_key "organizations", "volunteer_centers"

--- a/spec/models/donor_spec.rb
+++ b/spec/models/donor_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Donor, type: :model do
-end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Membership, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Add a membership model that belongs to an organization and a user, and removes the donor model. The membership model not represents the concept of a donor, so the model and table are no longer necessary.

This also adds a first name and last name to a user. We need to store and display that information and I figured I would add that while the patient is open.

I believe that no changes are made if the migration fails at any point, but as a sanity check I would appreciate if someone would checkout this branch and run `rake db:migrate`

Also, solves #34 
