### PR TITLE
style active admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'cancancan'
 gem 'dotenv-rails'
 gem 'paperclip'
 gem 'aws-sdk', '< 2.0'
+gem 'active_skin'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_skin (0.0.12)
     activejob (4.2.6)
       activesupport (= 4.2.6)
       globalid (>= 0.3.0)
@@ -277,6 +278,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_skin
   activeadmin!
   annotate
   autoprefixer-rails

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -10,6 +10,7 @@
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "active_admin/base";
+@import "active_skin";
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:


### PR DESCRIPTION
bring in another gem to style active admin for us.

before:
<img width="1436" alt="screen shot 2016-06-18 at 7 27 45 pm" src="https://cloud.githubusercontent.com/assets/3501927/16174316/db9fa65e-358a-11e6-8f06-7627041361fb.png">

after: 
<img width="1421" alt="screen shot 2016-06-18 at 7 27 30 pm" src="https://cloud.githubusercontent.com/assets/3501927/16174320/e28b15c0-358a-11e6-91d5-e8e49a7ad9a5.png">
