### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3.0
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.4"
 
 before_script:
   - psql -c 'create database share_christmas_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ rvm:
 addons:
   postgresql: "9.5"
 
+before_script:
+  - psql -c 'create database share_christmas_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+sudo: false
+
+rvm:
+  - 2.3.0
+
+addons:
+  postgresql: "9.5"
+

--- a/.travis.yml~
+++ b/.travis.yml~
@@ -7,3 +7,5 @@ rvm:
 addons:
   postgresql: "9.5"
 
+before_script:
+  - psql -c 'create database share_christmas_test;' -U postgres

--- a/.travis.yml~
+++ b/.travis.yml~
@@ -1,0 +1,9 @@
+language: ruby
+sudo: false
+
+rvm:
+  - 2.3.0
+
+addons:
+  postgresql: "9.5"
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/rubyforgood/share_christmas.svg?branch=master)](https://travis-ci.org/rubyforgood/share_christmas)
+
 # Share Your Holiday
 
 It is an unfortunate reality that not every child has presents under their Christmas tree.

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,7 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+RSpec::Core::RakeTask.new
+
+task :default => :spec


### PR DESCRIPTION
Add support for TravisCI for automatic tests.  For the time being, I'm leaving the defaults to run the TravisCI build on Pull Requests (but merging into master can be done even if the tests don't pass), and Merging into Master.  

Had to set Postgres version at 9.4, which is one level behind our standard of 9.5  However, according to https://github.com/travis-ci/travis-ci/issues/4264, support for 9.5 is imminent, and we can make the change to `.travis.yml` when that occurs.  
