### PR TITLE
Create tmp folder if it doesn't exist

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -28,5 +28,6 @@ Dir.chdir APP_ROOT do
   system 'rm -rf tmp/cache'
 
   puts "\n== Restarting application server =="
+  system 'mkdir tmp' unless Dir.exist?('tmp')
   system 'touch tmp/restart.txt'
 end


### PR DESCRIPTION
Cloning the project and running bin/setup, will produce the following error:

``` bash
== Restarting application server ==  
touch: cannot touch 'tmp/restart.txt': No such file or directory
```
