### PR TITLE
[DRAFT] Add admin organization Management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rolify'
 gem 'sass-rails', '~> 5.0'
 gem 'tinymce-rails', github: 'spohlenz/tinymce-rails'
 gem 'uglifier', '>= 1.3.0'
+gem 'will_paginate'
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -322,6 +323,7 @@ DEPENDENCIES
   tinymce-rails!
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  will_paginate
 
 RUBY VERSION
    ruby 2.3.0p0

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -39,11 +39,6 @@ class OrganizationsController < ApplicationController
     @organization = Organization.friendly.find(params[:id])
   end
 
-  def switch_current_campaign
-    session[:current_campaign] = params[:organization_campaign][:campaign_id]
-    redirect_to organization_path(params[:id])
-  end
-
   private
 
   def find_organization_campaign

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,6 +3,10 @@ class OrganizationsController < ApplicationController
   load_and_authorize_resource
   layout 'org_admin'
 
+  def index
+    @organizations = Organization.alphabetical.paginate(page: params[:page])
+  end
+
   def show
     @org = Organization.friendly.find(params[:id])
     @organization_campaign = find_organization_campaign

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,22 +1,61 @@
 class OrganizationsController < ApplicationController
-  before_action :authenticate_user!
-  load_and_authorize_resource
+  load_and_authorize_resource param_method: :organization_attributes,
+                              find_by: :slug,
+                              except: [:show, :index]
+
   layout 'org_admin'
 
   def index
     @organizations = Organization.alphabetical.paginate(page: params[:page])
   end
 
+  def new
+    @organization = Organization.new
+  end
+
+  def create
+    @organization = Organization.new(organization_attributes)
+    if @organization.save
+      redirect_to @organization, notice: "#{@organization.name} was successfully added!"
+    else
+      render 'new'
+    end
+  end
+
+  def edit
+    @organization = Organization.friendly.find(params[:id])
+  end
+
+  def update
+    @organization = Organization.friendly.find(params[:id])
+    if @organization.update_attributes(organization_attributes)
+      redirect_to @organization, notice: "#{@organization.name} was successfully updated!"
+    else
+      render 'edit'
+    end
+  end
+
   def show
-    @org = Organization.friendly.find(params[:id])
-    @organization_campaign = find_organization_campaign
-    @joined_campaigns = @org.campaigns
-    @joinable_campaigns = @org.joinable_campaigns
-    @organization_campaign_new = OrganizationCampaign.new(organization_id: @org.id)
+    @organization = Organization.friendly.find(params[:id])
   end
 
   def switch_current_campaign
     session[:current_campaign] = params[:organization_campaign][:campaign_id]
     redirect_to organization_path(params[:id])
+  end
+
+  private
+
+  def find_organization_campaign
+    session[:current_campaign] ||= @org.current_campaign.nil? ? nil : @org.current_campaign.id
+    return nil if session[:current_campaign].nil?
+    OrganizationCampaign.find_by_organization_id_and_campaign_id(
+      @org.id,
+      session[:current_campaign]
+    )
+  end
+
+  def organization_attributes
+    params.require(:organization).permit(:name, :description, :url)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,9 @@ class Ability
 
     can :manage, :all if user.has_role? :admin
 
-    can :manage, Organization,
-        id: Organization.with_role(:admin, user).pluck(:id)
+    unless user.new_record?
+      can :manage, Organization,
+          id: Organization.with_role('admin', user).pluck(:id)
+    end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -34,6 +34,8 @@ class Organization < ActiveRecord::Base
 
   validates_attachment_content_type :logo, content_type: %r{\Aimage\/.*\Z}
 
+  scope :alphabetical, -> { order(:name) }
+
   extend FriendlyId
   friendly_id :name, use: :slugged
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -21,7 +21,6 @@ class Organization < ActiveRecord::Base
 
   has_many :organization_campaigns
   has_many :campaigns, through: :organization_campaigns
-
   has_many :memberships
   has_many :users, through: :memberships
 
@@ -33,6 +32,10 @@ class Organization < ActiveRecord::Base
                     default_url: '/images/:style/missing.png'
 
   validates_attachment_content_type :logo, content_type: %r{\Aimage\/.*\Z}
+
+  # TODO: When dealing with multiple volunteer centers, we may have multiple organizations
+  # with the same name. We may have to add `scope: :volunteer_center_id`
+  validates :name, presence: true, uniqueness: true
 
   scope :alphabetical, -> { order(:name) }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,6 @@
   <%= render 'layouts/navbar' %>
   <%= render 'layouts/flash' %>
   <div class="container">
-    <% if defined?(@organization_campaign) && @organization_campaign.try(:campaign_logo) %>
-      <%= image_tag(@organization_campaign.campaign_logo.url, alt: "Logo", class: "header--logo") %>
-    <% end %>
-    <% if session[:organization_name] %>
-      <h1 class="header"><%= session[:organization_name] %></h1>
-    <% end %>
     <%= content_for?(:content) ? yield(:content) : yield %>
   </div>
   <%= javascript_include_tag 'application' %>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_for @organization do |f| %>
+  <div>
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+
+  <div>
+    <%= f.label :description %>
+    <div>
+      <%= f.text_area :description %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :url %>
+    <%= f.text_field :url %>
+  </div>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit <%= @organization.name %></h1>
+
+<%= render 'form' %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,0 +1,21 @@
+<h1>All Organizations</h1>
+
+<table class="table table-striped">
+  <thead>
+    <th>Name</th>
+    <th>Description</th>
+    <th>URL</th>
+    <th></th>
+  </thead>
+  <tbody>
+    <% @organizations.each do |organization| %>
+      <tr>
+        <td><%= link_to organization.name, organization_path(organization.id) %></td>
+        <td><%= organization.description %></td>
+        <td><%= link_to organization.url %></td>
+        <td><%= link_to 'Details', organization_path(organization.id), class: 'btn btn-default' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= will_paginate @organizations %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -6,6 +6,9 @@
     <th>Description</th>
     <th>URL</th>
     <th></th>
+    <% if can? :manage, Organization %>
+      <th></th>
+    <% end %>
   </thead>
   <tbody>
     <% @organizations.each do |organization| %>
@@ -13,7 +16,10 @@
         <td><%= link_to organization.name, organization_path(organization.id) %></td>
         <td><%= organization.description %></td>
         <td><%= link_to organization.url %></td>
-        <td><%= link_to 'Details', organization_path(organization.id), class: 'btn btn-default' %></td>
+        <td><%= link_to 'Details', organization, class: 'btn btn-default' %></td>
+        <% if can? :manage, @organization %>
+          <td><%= link_to 'Edit', edit_organization_path(organization), class: 'btn btn-primary' %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Create New Organization</h1>
+
+<%= render 'form' %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,59 +1,25 @@
-<p>
-  Hello, <%= @org.name %>
-</p>
+<div class="sc-Org">
+  <h1><%= @organization.name %></h1>
 
-<p>
-<% if @organization_campaign %>
-  Your current campaign is <%= @organization_campaign.campaign.name %>
+  <div class="sc-Org-details">
+    <div class="sc-Org-details-attribute">
+      <strong>Name:</strong> <span><%= @organization.name %></span>
+    </div>
 
-  <table class="table">
-    <thead>
-      <tr>
-        <th>Assigned Recipients</th>
-        <th>Matched</th>
-        <th>Percent</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><%= @organization_campaign.assigned %></td>
-        <td><%= @organization_campaign.matched %></td>
-        <td><strong><%= @organization_campaign.matched_pct %></strong></td>
-      </tr>
-    </tbody>
-  </table>
+    <div class="sc-Org-details-attribute">
+      <strong>Description:</strong>
+      <p><%= @organization.name %></p>
+    </div>
 
-<% else %>
-  You are not joined to any campaign at the moment.  Perhaps you should join one!
-<% end %>
-</p>
+    <div class="sc-Org-details-attribute">
+      <strong>URL:</strong> <span><%= link_to @organization.url %></span>
+    </div>
+  </div>
 
-<% if @joinable_campaigns && @joinable_campaigns.count > 0 %>
-  <%= form_for @organization_campaign_new, 
-      url: {action: :create, controller: :organization_campaigns} do |f| %>
-    Join campaign: 
-    <%= f.hidden_field :organization_id %>
-    <%= f.collection_select(:campaign_id, @joinable_campaigns,:id, :name) %>
-    <%= f.submit "Join" %>
-  <% end %>
-<% end %>
-
-<% if @joined_campaigns && @joined_campaigns.count > 1 %>
-  <%= form_tag(switch_current_campaign_organization_path(params[:id]), method: "get") do  %>
-    Switch to campaign: 
-    <%= collection_select(:organization_campaign, :campaign_id, @joined_campaigns,:id,:name) %>
-    <%= submit_tag("Switch") %>
-  <% end %>
-<% end %>
-
-<ul>
-<li><%= link_to 'Import Member Email List', import_emails_form_organization_path(@org) %></li>
-<li><%= link_to 'Member List',organization_memberships_path(@org) %></li>
-<% if @organization_campaign %>
-  <li><%= link_to 'Send Emails', send_email_form_organization_campaign_path(@organization_campaign) %></li>
-  <li><%= link_to 'Unmatched Recipient Report', recipients_path(organization_campaign: @organization_campaign, matched:false, format: :print) %></li>
-  <li><%= link_to 'Match Report', recipients_path(organization_campaign: @organization_campaign, matched: true) %></li>
-  <li><%= link_to 'Manually Match or Unmatch', organization_recipients_path(@org) %></li>
-<% end %>
-<li><%= link_to 'Add or Remove Administrators', organization_org_admins_path(@org) %></li>
-</ul>
+  <div class="sc-Org-actions">
+    <%= link_to 'All Organizations', organizations_path, class: 'btn btn-default' %>
+    <% if can? :edit, @organization %>
+      <%= link_to 'Edit', edit_organization_path(@organization), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :organizations, only: [:show, :index] do
+  resources :organizations, except: :destroy do
     resources :org_admins, only: [:index, :create, :destroy]
     resources :memberships
     resources :recipients, only: [:index, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :organizations, only: [:show] do
+  resources :organizations, only: [:show, :index] do
     resources :org_admins, only: [:index, :create, :destroy]
     resources :memberships
     resources :recipients, only: [:index, :edit, :update]

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -84,7 +84,12 @@ RSpec.describe MembershipsController, type: :controller do
     end
 
     it 'matches user if recipient is given' do
-      recip = FactoryGirl.create(:recipient)
+      oc = FactoryGirl.create(:organization_campaign, organization: org)
+      recip_family = FactoryGirl.create(:recipient_family, organization_campaign: oc)
+      recip = FactoryGirl.create(:recipient, first_name: 'Wesley', last_name: 'Wallace',
+                                             organization_campaign: oc,
+                                             recipient_family: recip_family)
+
       post :create, organization_id: org.id, user: willy_smith_attr, recipient_id: recip.id
       recip.reload
       expect(recip.membership).to eq Membership.first
@@ -135,7 +140,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe 'destroy >' do
     it 'will remove membership record and leave user record' do
       subject.current_user.add_role(:admin, org)
-      m = FactoryGirl.create(:membership, user: subject.current_user)
+      m = FactoryGirl.create(:membership, user: subject.current_user, organization: org)
 
       expect do
         delete :destroy, organization_id: org.id, id: m.id

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe 'edit >' do
     it 'will look up user and membership record' do
       subject.current_user.add_role(:admin, org)
-      m = FactoryGirl.create(:membership, user: subject.current_user)
+      m = FactoryGirl.create(:membership, user: subject.current_user, organization: org)
 
       get :edit, organization_id: org.id, id: m.id
       expect(assigns(:user)).to eq m.user
@@ -105,7 +105,7 @@ RSpec.describe MembershipsController, type: :controller do
   describe 'update >' do
     # This literally changes the logged-in user's record underneath, but
     # there's no real problem with that.
-    let(:m) { FactoryGirl.create(:membership, user: subject.current_user) }
+    let(:m) { FactoryGirl.create(:membership, user: subject.current_user, organization: org) }
     let(:willy_smith_user_attr) { willy_smith_attr.except(:membership) }
     before(:each) { subject.current_user.add_role(:admin, org) }
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,56 +1,92 @@
 require 'rails_helper'
 
 RSpec.describe OrganizationsController, type: :controller do
-  let(:org) { FactoryGirl.create(:organization) }
-  before(:each) { login_user }
+  render_views
+  let(:org) { FactoryGirl.create(:organization, name: 'Test Organization') }
 
-  describe 'show > ' do
-    context 'users who are not admins of this org > ' do
-      it 'will be denied access' do
-        expect do
-          get :show, id: org.id
-        end.to raise_error(CanCan::AccessDenied)
+  describe 'index' do
+    it 'successfully responds' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'show' do
+    it 'will see organization information' do
+      get :show, id: org.id
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'create' do
+    let(:org_params) { { name: 'test' } }
+
+    context 'when not logged in' do
+      it 'does not add an organization' do
+        expect { post :create, organization: org_params }.to raise_error(CanCan::AccessDenied)
       end
     end
 
-    context 'users who are an org_admin of this org > ' do
-      before(:each) { subject.current_user.add_role(:admin, org) }
+    context 'when logged in' do
+      before { login_user(admin: true) }
 
-      it 'will see page' do
-        get :show, id: org.id
-        expect(response).to be_successful
-      end
-
-      it "will not see a current campaign, if they haven't joined one" do
-        get :show, id: org.id
-        expect(assigns(:organization_campaign)).to be_nil
-        expect(assigns(:joined_campaigns)).to be_empty
-        expect(assigns(:joinable_campaigns)).to be_empty
-        expect(assigns(:organization_campaign_new)).to be_a_new(OrganizationCampaign)
-      end
-
-      it 'will see their current campaign' do
-        oc = FactoryGirl.create :organization_campaign, organization: org
-        get :show, id: org.id
-        expect(assigns(:organization_campaign)).to eq oc
-        expect(assigns(:joined_campaigns)).to eq [oc.campaign]
+      it 'adds an organization' do
+        expect { post :create, organization: org_params }.to change { Organization.count }
       end
     end
   end
 
-  describe 'switch_current_campaign > ' do
-    let(:c) { FactoryGirl.create :campaign }
-    before(:each) do
-      subject.current_user.add_role(:admin, org)
-      get :switch_current_campaign, id: org.id, organization_campaign: { campaign_id: c.id }
+  describe 'new' do
+    context 'when not logged in' do
+      it 'redirects because not authorized' do
+        expect { get :new }.to raise_error(CanCan::AccessDenied)
+      end
     end
 
-    it 'changes session variable for current_campaign ' do
-      expect(session[:current_campaign]).to eq c.id.to_s
+    context 'when logged in' do
+      before { login_user(admin: true) }
+
+      it 'successfully renders a page' do
+        get :new
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe 'edit' do
+    context 'when not logged in' do
+      it 'redirects because not authorized' do
+        expect { get :edit, id: org.slug }.to raise_error(CanCan::AccessDenied)
+      end
     end
 
-    it 'redirects to org page ' do
-      expect(response).to redirect_to organization_path(org.id)
+    context 'when logged in' do
+      before { login_user(admin: true) }
+
+      it 'successfully renders a page' do
+        get :edit, id: org.slug
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+
+  describe 'update' do
+    let(:org_params) { { name: 'testtesttest' } }
+
+    context 'when not logged in' do
+      it 'is not authorized' do
+        expect { put :update, id: org.slug, organization: org_params }
+          .to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context 'when logged in' do
+      before { login_user(admin: true) }
+
+      it 'updates the org' do
+        put :update, id: org.slug, organization: org_params
+        expect(org.reload.name).to eq('testtesttest')
+      end
     end
   end
 end

--- a/spec/controllers/recipients_controller_spec.rb
+++ b/spec/controllers/recipients_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RecipientsController, type: :controller do
   end
 
   describe 'edit >' do
-    let(:r) { FactoryGirl.create(:recipient) }
+    let(:r) { FactoryGirl.create(:recipient, organization_campaign: oc) }
     before(:each) { subject.current_user.add_role(:admin, org) }
 
     it 'loads recipient record, and members of org' do

--- a/spec/controllers/recipients_controller_spec.rb
+++ b/spec/controllers/recipients_controller_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RecipientsController, type: :controller do
-  let(:org) { FactoryGirl.create(:organization) }
+  let!(:org) { FactoryGirl.create(:organization, name: 'Boy Scouts') }
+  let!(:oc) { FactoryGirl.create(:organization_campaign, organization: org) }
   before(:each) { login_user }
 
   describe 'index >' do
@@ -34,12 +35,10 @@ RSpec.describe RecipientsController, type: :controller do
     end
   end
 
-  describe 'update >' do
-    let(:r) { FactoryGirl.create(:recipient) }
-    let(:alternate_user) do
-      FactoryGirl.create(:user, email: 'someoneelse@admin.org', reset_password_token: 'None')
-    end
-    let(:m) { FactoryGirl.create(:membership, user: alternate_user) }
+  describe "update >" do
+    let(:r) { FactoryGirl.create(:recipient, organization_campaign: oc) }
+    let(:alternate_user) {FactoryGirl.create(:user, email: "someoneelse@admin.org", reset_password_token:"None")}
+    let(:m) { FactoryGirl.create(:membership, user: alternate_user, organization: org) }
 
     it 'updates recipient record' do
       expect(r.membership_id).to_not eq m.id

--- a/spec/controllers/recipients_controller_spec.rb
+++ b/spec/controllers/recipients_controller_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe RecipientsController, type: :controller do
     end
   end
 
-  describe "update >" do
+  describe 'update >' do
     let(:r) { FactoryGirl.create(:recipient, organization_campaign: oc) }
-    let(:alternate_user) {FactoryGirl.create(:user, email: "someoneelse@admin.org", reset_password_token:"None")}
+    let(:alternate_user) { FactoryGirl.create(:user, email: 'someoneelse@admin.org', reset_password_token: 'None') }
     let(:m) { FactoryGirl.create(:membership, user: alternate_user, organization: org) }
 
     it 'updates recipient record' do

--- a/spec/models/organization_campaign_spec.rb
+++ b/spec/models/organization_campaign_spec.rb
@@ -15,7 +15,8 @@
 require 'rails_helper'
 
 describe OrganizationCampaign do
-  let(:oc) { FactoryGirl.create :organization_campaign }
+  let(:org) { FactoryGirl.create :organization, name: 'Church' }
+  let(:oc) { FactoryGirl.create :organization_campaign, organization: org }
 
   describe 'Factories >' do
     it 'has a valid factory' do
@@ -41,7 +42,7 @@ describe OrganizationCampaign do
       end
 
       it 'returns >0 if some recipients are matched' do
-        membership = FactoryGirl.create(:membership)
+        membership = FactoryGirl.create(:membership, organization: org)
         FactoryGirl.create :recipient, organization_campaign: oc, membership: membership
         expect(oc.matched).to eq 1
       end
@@ -53,7 +54,7 @@ describe OrganizationCampaign do
       end
 
       it 'returns >0 if some recipients are matched' do
-        membership = FactoryGirl.create(:membership)
+        membership = FactoryGirl.create(:membership, organization: org)
         FactoryGirl.create :recipient, organization_campaign: oc, membership: membership
         expect(oc.matched_pct).to eq 100
       end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -18,12 +18,12 @@
 require 'rails_helper'
 
 describe Organization do
-  describe 'Scopes >' do
-    before do
-      FactoryGirl.create(:organization, name: 'b')
-      FactoryGirl.create(:organization, name: 'a')
-    end
+  before(:all) do
+    FactoryGirl.create(:organization, name: 'b')
+    FactoryGirl.create(:organization, name: 'a')
+  end
 
+  describe 'Scopes >' do
     it 'has a scope to order organizations alphabetically' do
       expect(Organization.alphabetical.pluck(:name)).to eq(%w(a b))
     end
@@ -49,6 +49,20 @@ describe Organization do
         oc = FactoryGirl.create :organization_campaign
         expect(oc.organization.current_campaign).to eq oc.campaign
       end
+    end
+  end
+
+  describe 'name validations' do
+    it 'must have a name' do
+      org = Organization.new
+      org.valid?
+      expect(org.errors).to include(:name)
+    end
+
+    it 'must have a unique name' do
+      org = Organization.new(name: 'a')
+      org.valid?
+      expect(org.errors).to include(:name)
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -19,6 +19,14 @@ require 'rails_helper'
 
 describe Organization do
   describe 'Scopes >' do
+    before do
+      FactoryGirl.create(:organization, name: 'b')
+      FactoryGirl.create(:organization, name: 'a')
+    end
+
+    it 'has a scope to order organizations alphabetically' do
+      expect(Organization.alphabetical.pluck(:name)).to eq(%w(a b))
+    end
   end
 
   describe 'Class Methods >' do

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -21,7 +21,9 @@
 require 'rails_helper'
 
 RSpec.describe Recipient, type: :model do
-  let(:r) { FactoryGirl.create :recipient }
+  let(:org) { FactoryGirl.create :organization, name: 'Company' }
+  let(:oc) { FactoryGirl.create :organization_campaign, organization: org }
+  let(:r) { FactoryGirl.create :recipient, organization_campaign: oc }
 
   describe 'Factories >' do
     it 'has a valid factory' do

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -44,12 +44,16 @@ RSpec.describe Recipient, type: :model do
       end
 
       it 'returns Race if race is recorded' do
-        r2 = FactoryGirl.create(:recipient, race: 'African-American')
+        r2 = FactoryGirl.build(:recipient, race: 'African-American', organization_campaign: oc)
         expect(r2.other_details).to eq 'Race: African-American'
       end
 
       it 'returns Race and size if both are recorded' do
-        r2 = FactoryGirl.create(:recipient, race: 'African-American, Size: 4')
+        r2 = FactoryGirl.build(:recipient,
+                               race: 'African-American',
+                               size: 4,
+                               organization_campaign: oc)
+
         expect(r2.other_details).to eq 'Race: African-American, Size: 4'
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,6 +107,12 @@ RSpec.configure do |config|
 
   config.include Devise::TestHelpers, type: :controller
   config.include ControllerMacros, type: :controller
+
+  RSpec.configure do |c|
+    # filter_run is short-form alias for filter_run_including
+    c.filter_run focus: true
+    c.run_all_when_everything_filtered = true
+  end
 end
 
 Capybara.default_driver = :poltergeist

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,9 +1,9 @@
 module ControllerMacros
-  def login_user
+  def login_user(admin: false)
     @request.env['devise.mapping'] = Devise.mappings[:user]
-    # Don't create the user twice
     user = User.find_by_email(FactoryGirl.attributes_for(:user)[:email])
     user = FactoryGirl.create(:user) unless user
+    user.add_role(:admin) if admin
     sign_in user
   end
 end


### PR DESCRIPTION
This adds the ability for an administrator of the site to manage organizations.

This assumes that the only type of admin is a system admin. Some small adjustments to the authorization checks and the index action need to be made to support organization admins. 

This also adds a uniqueness validation on an organization name, and as a result I had to change some test setup. FactoryGirl tries to create a default organization every time it creates an associated record that doesn't specify an organization to use.

I felt some pain around the ability file for cancan and rolify. I got postgres errors when a new user has no roles added, and we try to authorize that user. I wrapped that in a condition to avoid that scenario, but it requires a closer look.
